### PR TITLE
perf: Greatly reduce memory usage by loading only the session currently viewed

### DIFF
--- a/src/lib/components/popup/sessions/CurrentSession.svelte
+++ b/src/lib/components/popup/sessions/CurrentSession.svelte
@@ -90,7 +90,8 @@
 		timeout = setTimeout(async () => {
 			$session = await getSession($settings.urlFilterList);
 
-			if ($settings.selectionId === 'current') selection.select($session);
+			if ($settings.selectionId === 'current')
+				selection.selectById($session.id);
 		}, 50);
 	}
 </script>

--- a/src/lib/components/popup/windows/Window.svelte
+++ b/src/lib/components/popup/windows/Window.svelte
@@ -18,7 +18,7 @@
 	let collapsed = false;
 </script>
 
-{#if window.tabs?.length}
+{#if window?.tabs?.length}
 	<ListItem let:hover class="rounded-md bg-neutral-2">
 		<!-- svelte-ignore a11y-click-events-have-key-events -->
 		<div

--- a/src/lib/stores/sessions.ts
+++ b/src/lib/stores/sessions.ts
@@ -12,8 +12,8 @@ export const sessions = (() => {
 
 	load();
 
-	async function load(count?: number) {
-		const sessions = await sessionsDB.loadSessions(count);
+	async function load() {
+		const sessions = await sessionsDB.lazyLoadSessions(undefined, 'prev');
 
 		set(sessions);
 
@@ -68,8 +68,8 @@ export const sessions = (() => {
 	}
 
 	function filter(query: string) {
-		const filtered: ESession[] = get({ subscribe })?.filter((session) =>
-			session?.title?.toLowerCase().includes(query)
+		const filtered: ESession[] = get({ subscribe })?.filter(
+			(session) => session?.title?.toLowerCase().includes(query)
 		);
 
 		return filtered; //subject to change

--- a/src/lib/stores/sessions.ts
+++ b/src/lib/stores/sessions.ts
@@ -40,7 +40,7 @@ export const sessions = (() => {
 		await sessionsDB.saveSession(generated);
 
 		update((sessions) => {
-			generated.windows = { length: generated.windows.length } as EWindow[];
+			generated.windows = { length: generated.windows.length } as EWindow[]; //unref the obj for GC
 
 			sessions.push(generated);
 			return sessions;
@@ -60,7 +60,10 @@ export const sessions = (() => {
 		update((sessions) => {
 			target.dateModified = Date.now();
 
+			target.windows = { length: target.windows.length } as EWindow[]; //unref the obj for GC
+
 			sessions[sessions.indexOf(target)] = target;
+
 			return sessions;
 		});
 

--- a/src/lib/stores/sessions.ts
+++ b/src/lib/stores/sessions.ts
@@ -40,13 +40,15 @@ export const sessions = (() => {
 		await sessionsDB.saveSession(generated);
 
 		update((sessions) => {
+			generated.windows = { length: generated.windows.length } as EWindow[];
+
 			sessions.push(generated);
 			return sessions;
 		});
 
-		notification.success(MESSAGES.save.success);
-
 		select(generated);
+
+		notification.success(MESSAGES.save.success);
 	}
 
 	async function put(target: ESession) {

--- a/src/lib/stores/sessions.ts
+++ b/src/lib/stores/sessions.ts
@@ -67,6 +67,8 @@ export const sessions = (() => {
 			return sessions;
 		});
 
+		selectById(target.id);
+
 		notification.success_info(MESSAGES.update.success_info);
 	}
 

--- a/src/lib/stores/sessions.ts
+++ b/src/lib/stores/sessions.ts
@@ -13,7 +13,7 @@ export const sessions = (() => {
 	load();
 
 	async function load() {
-		const sessions = await sessionsDB.lazyLoadSessions(undefined, 'prev');
+		const sessions = await sessionsDB.lazyLoadSessions();
 
 		set(sessions);
 

--- a/src/lib/utils/database.ts
+++ b/src/lib/utils/database.ts
@@ -88,12 +88,12 @@ class SessionsDB {
 		return sessions;
 	}
 
-	async loadSession(id: UUID) {
+	async loadSessionWindows(id: UUID) {
 		log.info('[db.loadSession] init');
 
 		await this.initDB();
 
-		return this.db.get('sessions', id);
+		return (await this.db.get('sessions', id))?.windows;
 	}
 
 	async saveSession(session: ESession) {

--- a/src/lib/utils/database.ts
+++ b/src/lib/utils/database.ts
@@ -6,7 +6,7 @@ import {
 	type StoreNames
 } from 'idb/with-async-ittr';
 import type { UUID } from 'crypto';
-import type { ESession } from '@/lib/types';
+import type { ESession, EWindow } from '@/lib/types';
 import { log } from '@/lib/utils';
 
 interface DB extends DBSchema {
@@ -57,6 +57,35 @@ class SessionsDB {
 		await this.initDB();
 
 		return this.db.getAllFromIndex('sessions', 'dateSaved', query, count);
+	}
+
+	async lazyLoadSessions(
+		query?: number | IDBKeyRange,
+		direction?: IDBCursorDirection
+	) {
+		log.info('[db.lazyLoadSessions] init');
+
+		const sessions: ESession[] = [];
+
+		await this.initDB();
+
+		const tx = this.db.transaction('sessions').store.index('dateSaved');
+
+		for await (const cursor of tx.iterate(query, direction)) {
+			const { dateModified, dateSaved, id, title, tabsNumber, windows } =
+				cursor.value;
+
+			sessions.push({
+				dateModified,
+				dateSaved,
+				id,
+				title,
+				tabsNumber,
+				windows: { length: windows.length } as EWindow[]
+			});
+		}
+
+		return sessions;
 	}
 
 	async saveSession(session: ESession) {

--- a/src/lib/utils/database.ts
+++ b/src/lib/utils/database.ts
@@ -88,6 +88,14 @@ class SessionsDB {
 		return sessions;
 	}
 
+	async loadSession(id: UUID) {
+		log.info('[db.loadSession] init');
+
+		await this.initDB();
+
+		return this.db.get('sessions', id);
+	}
+
 	async saveSession(session: ESession) {
 		log.info('[db.saveSession] init');
 


### PR DESCRIPTION
When there is a lot of sessions with many tabs (think of 400+ sessions with each 150 tab+), memory usage increases greatly. There is no reason to load all the data for every session loaded, instead just load the session that is being viewed.